### PR TITLE
[WIP] Add teams functionality

### DIFF
--- a/Github/Data.hs
+++ b/Github/Data.hs
@@ -695,6 +695,18 @@ instance FromJSON ContentData where
                 <*> o .: "html_url"
   parseJSON _ = fail "Could not build a ContentData"
 
+instance FromJSON AddToTeamResponse where
+  parseJSON (Object o) = case Map.lookup "state" o of
+    Just "active"  -> pure AddedToTeam
+    Just "pending" -> pure InvitedToJoinTeam
+    Just _         -> fail "Bad reply from Github: added users must be either active or pending"
+    Nothing        -> fail "No \"state\" field in add to team response"
+  parseJSON _      =  fail "Could not build AddToTeamResponse"
+
+instance FromJSON DeleteResult where
+  parseJSON (Array _) = pure Deleted
+  parseJSON _         = pure DeleteFailed
+
 -- | A slightly more generic version of Aeson's @(.:?)@, using `mzero' instead
 -- of `Nothing'.
 (.:<) :: (FromJSON a) => Object -> T.Text -> Parser [a]

--- a/Github/Data.hs
+++ b/Github/Data.hs
@@ -707,6 +707,10 @@ instance FromJSON DeleteResult where
   parseJSON (Array _) = pure Deleted
   parseJSON _         = pure DeleteFailed
 
+instance FromJSON PublicKey where
+  parseJSON (Object o) = PublicKey <$> o .: "id" <*> o .: "key"
+  parseJSON _          = fail "Could not parse public keys from user"
+
 -- | A slightly more generic version of Aeson's @(.:?)@, using `mzero' instead
 -- of `Nothing'.
 (.:<) :: (FromJSON a) => Object -> T.Text -> Parser [a]

--- a/Github/Data.hs
+++ b/Github/Data.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 -- | This module re-exports the @Github.Data.Definitions@ module, adding
 -- instances of @FromJSON@ to it. If you wish to use the data without the
@@ -366,6 +366,18 @@ instance FromJSON PullRequest where
         <*> o .: "title"
         <*> o .: "id"
   parseJSON _ = fail "Could not build a PullRequest"
+
+instance FromJSON Team where
+  parseJSON (Object o) = Team <$> o .: "id"
+                              <*> o .: "url"
+                              <*> o .: "name"
+                              <*> o .: "description"
+                              <*> o .: "permission"
+                              <*> o .: "members_url"
+                              <*> o .: "repositories_url"
+  parseJSON _ = fail "Could not parse team document"
+
+
 
 instance ToJSON EditPullRequestState where
   toJSON (EditPullRequestStateOpen) = String "open"

--- a/Github/Data/Definitions.hs
+++ b/Github/Data/Definitions.hs
@@ -635,4 +635,6 @@ data EditPullRequestState =
 
 data AddToTeamResponse = AddedToTeam | InvitedToJoinTeam deriving (Show, Eq)
 
-data DeleteResult = Deleted | DeleteFailed deriving (Show)
+data DeleteResult = Deleted | DeleteFailed deriving Show
+
+data PublicKey = PublicKey Int String deriving Show

--- a/Github/Data/Definitions.hs
+++ b/Github/Data/Definitions.hs
@@ -632,3 +632,7 @@ data EditPullRequestState =
     EditPullRequestStateOpen
   | EditPullRequestStateClosed
   deriving Show
+
+data AddToTeamResponse = AddedToTeam | InvitedToJoinTeam deriving (Show, Eq)
+
+data DeleteResult = Deleted | DeleteFailed deriving (Show)

--- a/Github/Data/Definitions.hs
+++ b/Github/Data/Definitions.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, StandaloneDeriving #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 
 module Github.Data.Definitions where
 
@@ -271,7 +271,7 @@ data EventType =
   | Referenced    -- ^ The issue was referenced from a commit message. The commit_id attribute is the commit SHA1 of where that happened.
   | Merged        -- ^ The issue was merged by the actor. The commit_id attribute is the SHA1 of the HEAD commit that was merged.
   | Assigned      -- ^ The issue was assigned to the actor.
-  | Closed        -- ^ The issue was closed by the actor. When the commit_id is present, it identifies the commit that closed the issue using “closes / fixes #NN” syntax. 
+  | Closed        -- ^ The issue was closed by the actor. When the commit_id is present, it identifies the commit that closed the issue using “closes / fixes #NN” syntax.
   | Reopened      -- ^ The issue was reopened by the actor.
   | ActorUnassigned    -- ^ The issue was unassigned to the actor
   | Labeled       -- ^ A label was added to the issue.
@@ -320,6 +320,16 @@ data Organization = Organization {
   ,organizationName :: Maybe String
   ,organizationId :: Int
 } deriving (Show, Data, Typeable, Eq, Ord)
+
+data Team = Team {
+    teamId              :: Int
+  , teamUrl             :: String
+  , teamName            :: String
+  , teamDescription     :: Maybe String
+  , teamPermission      :: String
+  , teamMembersUrl      :: String
+  , teamRepositoriesUrl :: String
+  } deriving (Show, Data, Typeable, Eq, Ord)
 
 data PullRequest = PullRequest {
    pullRequestClosedAt :: Maybe GithubDate

--- a/Github/Organizations/Teams.hs
+++ b/Github/Organizations/Teams.hs
@@ -1,0 +1,11 @@
+module Github.Organizations.Teams ( teamsForOrganization
+                                  , membersForTeam) where
+
+import Github.Private
+import Github.Data
+
+teamsForOrganization :: GithubAuth -> String -> IO (Either Error [Team])
+teamsForOrganization auth orgName = githubGet' (Just auth) ["orgs", orgName, "teams"]
+
+membersForTeam :: GithubAuth -> Int -> IO (Either Error [GithubOwner])
+membersForTeam auth teamIdent = githubGet' (Just auth) ["teams", show teamIdent, "members"]

--- a/Github/Organizations/Teams.hs
+++ b/Github/Organizations/Teams.hs
@@ -1,11 +1,24 @@
 module Github.Organizations.Teams ( teamsForOrganization
-                                  , membersForTeam) where
+                                  , membersForTeam
+                                  , addToTeam
+                                  , deleteFromTeam) where
 
 import Github.Private
 import Github.Data
 
-teamsForOrganization :: GithubAuth -> String -> IO (Either Error [Team])
+type OrganizationName = String
+type TeamName         = String
+type GithubUser       = String
+type TeamId           = Int
+
+teamsForOrganization :: GithubAuth -> OrganizationName -> IO (Either Error [Team])
 teamsForOrganization auth orgName = githubGet' (Just auth) ["orgs", orgName, "teams"]
 
-membersForTeam :: GithubAuth -> Int -> IO (Either Error [GithubOwner])
+membersForTeam :: GithubAuth -> TeamName -> IO (Either Error [GithubOwner])
 membersForTeam auth teamIdent = githubGet' (Just auth) ["teams", show teamIdent, "members"]
+
+addToTeam :: GithubAuth -> TeamId -> GithubUser -> IO (Either Error AddToTeamResponse)
+addToTeam auth teamIdent githubUser = githubPut auth ["teams", show teamIdent, "memberships", githubUser]
+
+deleteFromTeam :: GithubAuth -> TeamId -> GithubUser -> IO (Either Error DeleteResult)
+deleteFromTeam auth teamIdent githubUser = githubDelete auth ["teams", show teamIdent, "memberships", githubUser]

--- a/Github/Users.hs
+++ b/Github/Users.hs
@@ -3,6 +3,7 @@
 module Github.Users (
  userInfoFor
 ,userInfoFor'
+,publicKeysForUser
 ,module Github.Data
 ) where
 
@@ -21,3 +22,6 @@ userInfoFor' auth userName = githubGet' auth ["users", userName]
 -- > userInfoFor "mike-burns"
 userInfoFor :: String -> IO (Either Error DetailedOwner)
 userInfoFor = userInfoFor' Nothing
+
+publicKeysForUser :: String -> Maybe GithubAuth -> IO (Either Error [PublicKey])
+publicKeysForUser username maybeAuth = githubGet' maybeAuth ["users", username, "keys"]

--- a/github.cabal
+++ b/github.cabal
@@ -7,7 +7,7 @@ Name:                github
 -- The package version. See the Haskell package versioning policy
 -- (http://www.haskell.org/haskellwiki/Package_versioning_policy) for
 -- standards guiding when and how versions should be incremented.
-Version:             0.13.1
+Version:             0.13.2
 
 -- A short (one-line) description of the package.
 Synopsis:            Access to the Github API, v3.
@@ -138,6 +138,7 @@ Library
                    Github.Issues.Milestones,
                    Github.Organizations,
                    Github.Organizations.Members,
+                   Github.Organizations.Teams,
                    Github.PullRequests,
                    Github.Repos,
                    Github.Repos.Collaborators,


### PR DESCRIPTION
I have added the required team functions and a function to retrieve public keys for a given user. The part of the library that actually makes the requests is messy and doesn't take into account that some responses might not have a body (much less a JSON body). There are a few ugly hacks that were necessary to get the core of the library to play nice with endpoints that return no body.

I have marked the ugly hacks as comments in the respective lines of code.